### PR TITLE
Bugfix: Fixing incorrect 'string' data type value in load_data

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -68,8 +68,7 @@ def load_data(PATH, type="csv"):
             parse_dates=["date"],
             date_parser=pd.to_datetime,
         )
-    except e:
-        print(e)
+    except:
         df = pd.DataFrame()
         print("Exception: Supports only csv file formats.")
     return df


### PR DESCRIPTION
- changed dtype "string" to "str"
Maybe, pandas versioning issue?
- Also only creating an empty dataframe when there is an error 

-- Checked that sales_model file works after this change.
One more version related error found, related to sklearn mse function. The new mean_squared_error function does not take a "sqaured" parameter. Please confirm if that's true.