### PR TITLE
Bugfix: last label of charts were cropped out

### DIFF
--- a/app/static/assets/js/dashboard/city_sales.js
+++ b/app/static/assets/js/dashboard/city_sales.js
@@ -163,8 +163,8 @@ try {
       borderColor: "#191e3a",
       strokeDashArray: 5,
       xaxis: { lines: { show: true } },
-      yaxis: { lines: { show: false } },
-      padding: { top: 0, right: 0, bottom: 0, left: -10 }
+      yaxis: { lines: { show: true } },
+      padding: { top: 0, right: 30, bottom: 0, left: 0 }
     },
     legend: {
       position: "top",

--- a/app/static/assets/js/dashboard/dept_quantity.js
+++ b/app/static/assets/js/dashboard/dept_quantity.js
@@ -148,7 +148,7 @@ try {
       strokeDashArray: 5,
       xaxis: { lines: { show: true } },
       yaxis: { lines: { show: false } },
-      padding: { top: 0, right: 0, bottom: 0, left: -10 }
+      padding: { top: 0, right: 30, bottom: 0, left: 0 }
     },
     legend: {
       position: "top",


### PR DESCRIPTION
The first label not present is an issue with apex charts that has to be fixed on their end. 
The last label was cropped by half - this is fixed by increasing the padding on right.
closes #58 